### PR TITLE
Fix pasting html text not working in chrome (windows)

### DIFF
--- a/src/wysihtml5/helpers/clipboard_integrator.js
+++ b/src/wysihtml5/helpers/clipboard_integrator.js
@@ -16,8 +16,9 @@ var ClipboardIntegrator = Base.extend({
       var host = document.createElement("div");
       host.innerHTML = content;
       this.composer.parent.parse(host);
-      host.normalize();
       removeEmptyTextNodes(host);
+      host.normalize();
+
       var fragment = nodeList.toArray(host.childNodes);
 
       for (var i = 0; i < fragment.length; i++) {


### PR DESCRIPTION
In chrome for windows, a paste event would look something like this:

`"\n"<!--documentfragment-->Text here<!--/documentfragment-->"\n"`

When node.normalize was called, it would remove the html comments and
combine the leading trailing newlines with the text.

Then, when `removeEmptyTextNodes` was called, nothing would be removed
since the single text node did have content: `\nText here\n`

Because when we convert this plan text to paragraph tags, we only expect
one result back, so the first "paragraph" was an empty `<p></p>` (the newline)
and the next paragraph, with the text we actually cared about, was
being discarded.

This simply removes empty nodes _before_ normalizing, instead of after,
and that solves our problem.

https://app.bananastand.org/workspaces/1/tasks/5640638