### PR TITLE
Treat line separator as new line

### DIFF
--- a/src/wysihtml5/helpers/clipboard_integrator.js
+++ b/src/wysihtml5/helpers/clipboard_integrator.js
@@ -29,7 +29,7 @@ var ClipboardIntegrator = Base.extend({
 
       this.elements = fragment;
     } else if (mime === "text/plain") {
-      var fragment = content.split(/\n+/);
+      var fragment = content.split(/\n+|\u2028+/);
       for (var i = 0; i < fragment.length; i++) {
         fragment[i] = document.createTextNode(fragment[i]);
       }


### PR DESCRIPTION
Acknowledge line separators while coping content into the editor.
Treats it the same was as a new-line; collapses them into a single
paragraph. Ideally it would insert a `br` instead of a paragraph, but
it was too complicated for the time being.