### PR TITLE
Add support for shift+enter to insert line breaks on mac

### DIFF
--- a/src/wysihtml5/keyboard/line_break.js
+++ b/src/wysihtml5/keyboard/line_break.js
@@ -1,0 +1,31 @@
+import { Constants } from "../constants";
+import { Composer } from "../views/composer";
+import dom from "../dom";
+
+/**
+ * Emulate native browser behaviour of Shift-Enter inserting a <br> instead
+ * of a new paragraph.
+**/
+Composer.RegisterKeyboardHandler(function(e) {
+  return (
+      e.type === "keydown" &&
+      e.keyCode == Constants.ENTER_KEY &&
+      e.shiftKey
+  );
+}, function(editor, composer, e) {
+    var breakElement = document.createElement("br"),
+        selectedNode = composer.selection.getSelectedNode();
+    e.preventDefault();
+
+    if (selectedNode.nodeName === "P") {
+      selectedNode.appendChild(breakElement);
+    } else if (selectedNode.nodeName === "BR") {
+      dom.insert(breakElement).after(selectedNode);
+    } else {
+      var initialBreakElement = document.createElement("br");
+      dom.insert(initialBreakElement).after(selectedNode);
+      dom.insert(breakElement).after(initialBreakElement);
+    }
+
+    composer.selection.setAfter(breakElement);
+});


### PR DESCRIPTION
Chrome and windows does this by default but mac/safari does ctrl+enter.

This update allows people in safari to also use shift+enter so that the behaviour is consistent.

----

I _really_ wanted to write tests for this and I spent some time installing the dependcies to get selenium working but I got stuck with firefox booting and immediately crashing whenever I ran `npm test` ...any thoughts?