### PR TITLE
Fix text pasting bug when it ended with a line break

### DIFF
--- a/src/wysihtml5/helpers/clipboard_integrator.js
+++ b/src/wysihtml5/helpers/clipboard_integrator.js
@@ -3,6 +3,7 @@ import { appendChildNodes } from "../dom/append_child_nodes";
 import { nodeList } from "../dom/node_list";
 import { fromPlainText } from "./from_plain_text";
 import { removeEmptyTextNodes } from "../dom/remove_empty_text_nodes";
+import { removeTrailingLineBreaks } from "../dom/remove_trailing_line_breaks"
 import { splitNode } from "./split_node";
 import { containsContent } from "./contains_content";
 var ClipboardIntegrator = Base.extend({
@@ -17,7 +18,7 @@ var ClipboardIntegrator = Base.extend({
       host.innerHTML = content;
       this.composer.parent.parse(host);
       removeEmptyTextNodes(host);
-      host.normalize();
+      host = removeTrailingLineBreaks(host);
 
       var fragment = nodeList.toArray(host.childNodes);
 


### PR DESCRIPTION
When text is pasted in, elements are properly renamed according to the editor
rules (for example, all `div` tags renamed to `p` tags etc)

However, if there was a trailing line break, that isn't part of the parser
sanitizing, and it would be inserted at the top level (under composer). Then,
the next time the user inserted a few line breaks, the editor would start
inserting div tags instead of paragraphs.

This would manifest in a funny way: The next time you tried to paste content,
the code to find the block element to paste the content in searched for P, h1,
blockquote, li, etc, BUT NOT DIV So the div you were in would be ignored and the
pasted text would end up in the wrong place.

One solution would have been to just add div to that array of allowed nodes, but
we clearly are replacing divs with paragraphs intentionally, so it seemed more
correct to strip trailing line breaks and stop it from happening in the first
place.

----

You'll notice I removed the `.normalize` in there and replaced it with the line
break stripping. This is just because the line break stripping method also runs
a `normalize` so it seemed pointless to do it twice.

https://app.bananastand.org/teams/52/workspaces/1/tasks/5658726