### PR TITLE
Use correct reference name for event in shortcuts

### DIFF
--- a/src/wysihtml5/keyboard/shortcuts.js
+++ b/src/wysihtml5/keyboard/shortcuts.js
@@ -14,6 +14,6 @@ Composer.RegisterKeyboardHandler(function(e) {
   var command = SHORTCUTS[e.keyCode];
   if (command) {
     composer.commands.exec(command);
-    event.preventDefault();
+    e.preventDefault();
   }
 });


### PR DESCRIPTION
`event` is not defined here, we should be using `e` instead.